### PR TITLE
Add Streamlit SARIMA forecasting app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
-# main-page
+# Sales Forecasting App
+
+This repository contains a Streamlit application that forecasts sales using the SARIMA method. You can upload multiple CSV files with `date` and `value` columns. The app displays interactive charts for each file and a table summarizing RMSE and MAPE metrics.
+
+## Setup
+
+Install the requirements:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Running
+
+```bash
+streamlit run app.py
+```
+

--- a/app.py
+++ b/app.py
@@ -1,0 +1,62 @@
+import streamlit as st
+import pandas as pd
+import numpy as np
+import plotly.express as px
+from statsmodels.tsa.statespace.sarimax import SARIMAX
+
+
+def calculate_metrics(actual: pd.Series, predicted: pd.Series):
+    rmse = np.sqrt(np.mean((actual - predicted) ** 2))
+    mape = np.mean(np.abs((actual - predicted) / actual)) * 100
+    return rmse, mape
+
+
+def sarima_forecast(df: pd.DataFrame, steps: int = 12):
+    df = df.sort_index()
+    train = df.iloc[:-steps]
+    test = df.iloc[-steps:]
+    model = SARIMAX(train['value'], order=(1, 1, 1), seasonal_order=(1, 1, 1, 12))
+    results = model.fit(disp=False)
+    forecast = results.predict(start=test.index[0], end=test.index[-1])
+    rmse, mape = calculate_metrics(test['value'], forecast)
+    combined = pd.concat([train['value'], test['value']], axis=0)
+    forecast_full = pd.Series(index=combined.index, dtype=float)
+    forecast_full.loc[test.index] = forecast
+    return forecast_full, rmse, mape, combined
+
+
+def main():
+    st.title('SARIMA Sales Forecasting')
+    st.write('Upload CSV files with `date` and `value` columns.')
+
+    uploaded_files = st.file_uploader('Upload CSVs', type='csv', accept_multiple_files=True)
+    metrics_rows = []
+
+    if uploaded_files:
+        for file in uploaded_files:
+            st.header(f'File: {file.name}')
+            df = pd.read_csv(file)
+            if 'date' not in df.columns or 'value' not in df.columns:
+                st.error('CSV must contain `date` and `value` columns.')
+                continue
+
+            df['date'] = pd.to_datetime(df['date'])
+            df.set_index('date', inplace=True)
+            forecast, rmse, mape, series = sarima_forecast(df)
+
+            plot_df = pd.DataFrame({'actual': series, 'forecast': forecast})
+            fig = px.line(plot_df, x=plot_df.index, y=['actual', 'forecast'],
+                          labels={'value': 'Value', 'index': 'Date'},
+                          title=f'Actual vs Forecast - {file.name}')
+            st.plotly_chart(fig, use_container_width=True)
+
+            metrics_rows.append({'File': file.name, 'RMSE': rmse, 'MAPE': mape})
+
+    if metrics_rows:
+        st.subheader('Metrics')
+        metrics_df = pd.DataFrame(metrics_rows)
+        st.dataframe(metrics_df)
+
+
+if __name__ == '__main__':
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
-     pandas
-     numpy
+pandas
+numpy
+streamlit
+statsmodels
+plotly


### PR DESCRIPTION
## Summary
- update README with instructions to run the SARIMA app
- list required dependencies
- implement `app.py` to upload multiple CSVs and show interactive SARIMA forecasts with RMSE and MAPE metrics

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_684dffad25f8832ca0a48df85920ddb7